### PR TITLE
Fix: ES module import error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-days-js",
-  "version": "2.2.1-alpha.0",
+  "version": "2.2.1-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-days-js",
-      "version": "2.2.1-alpha.0",
+      "version": "2.2.1-alpha.1",
       "license": "MIT",
       "dependencies": {
         "date-holidays": "^3.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-days-js",
-  "version": "2.2.1-alpha.1",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-days-js",
-      "version": "2.2.1-alpha.1",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "date-holidays": "^3.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-days-js",
-  "version": "2.1.2",
+  "version": "2.2.1-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-days-js",
-      "version": "2.1.2",
+      "version": "2.2.1-alpha.0",
       "license": "MIT",
       "dependencies": {
         "date-holidays": "^3.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-days-js",
-  "version": "2.2.1-alpha.1",
+  "version": "2.2.1",
   "description": "Checks whether a date is on a weekend or a U.S. holiday",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-days-js",
-  "version": "2.2.0",
+  "version": "2.2.1-alpha.0",
   "description": "Checks whether a date is on a weekend or a U.S. holiday",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "2.2.0",
   "description": "Checks whether a date is on a weekend or a U.S. holiday",
   "source": "src/index.js",
-  "exports": {
-    "require": "./dist/index.cjs",
-    "default": "./dist/index.modern.js"
-  },
   "main": "dist/index.js",
   "module": "dist/index.module.js",
   "unpkg": "dist/index.umd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-days-js",
-  "version": "2.2.1-alpha.0",
+  "version": "2.2.1-alpha.1",
   "description": "Checks whether a date is on a weekend or a U.S. holiday",
   "source": "src/index.js",
   "main": "dist/index.js",


### PR DESCRIPTION
## What's this PR do?
Fixes a bug introduced in v2.2.0 relating to the dist files.

## Why are we doing this? How does it help us?
This essentially reverts a small change made to `package.json` in v2.2.0 that wasn't properly tested (my bad!). It caused the package to fail to load as an ES Module.

## Are there any smells or added technical debt to note?

## TODOs / next steps:
<!-- Remove any checklist items that don't apply to your PR. -->
<!-- Examples:  "Run django migration," "Slack notify #all-general," etc. -->
* [ ] *your TODO here*
