### PR TITLE
Update references to Juneteenth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-days-js",
-  "version": "2.2.2-alpha-0",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-days-js",
-      "version": "2.2.2-alpha-0",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "date-holidays": "^3.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-days-js",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-days-js",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "date-holidays": "^3.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "business-days-js",
-  "version": "2.2.2",
+  "version": "2.2.2-alpha-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "business-days-js",
-      "version": "2.2.2",
+      "version": "2.2.2-alpha-0",
       "license": "MIT",
       "dependencies": {
         "date-holidays": "^3.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-days-js",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Checks whether a date is on a weekend or a U.S. holiday",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-days-js",
-  "version": "2.2.2",
+  "version": "2.2.2-alpha-0",
   "description": "Checks whether a date is on a weekend or a U.S. holiday",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "business-days-js",
-  "version": "2.2.2-alpha-0",
+  "version": "2.2.2",
   "description": "Checks whether a date is on a weekend or a U.S. holiday",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ import businessDays from "business-days-js";
 
 const bDays = businessDays();
 ```
-By default, businessDays treats 10 U.S. public holidays as non-business days. To use state-specific public holidays, instead initialize businessDays with an appropriate two-letter state abbreviation:
+By default, businessDays treats 11 U.S. public holidays as non-business days. To use state-specific public holidays, instead initialize businessDays with an appropriate two-letter state abbreviation:
 
 ```
 import businessDays from "business-days-js";
@@ -149,8 +149,8 @@ const CUSTOM_HOLIDAYS = [
     name: "Groundhog Day",
   },
   {
-    rule: "06-19",
-    name: "Juneteenth",
+    rule: "07-15",
+    name: "Saint Swithin's Day",
   },
 ]
 const bDays = businessDays({
@@ -164,12 +164,13 @@ const bDays = businessDays({
 
 ### Holidays and substitution days
 
-By default, when initialized without a state abbreviation, businessDays handles 10 U.S. public holidays as non-business days:
+By default, when initialized without a state abbreviation, businessDays hnadles the following 11 U.S. public holidays as non-business days:
 
 - New Year's Day
 - Martin Luther King Jr. Day
 - Washington's Birthday
 - Memorial Day
+- Juneteenth
 - Independence Day
 - Labor Day
 - Columbus Day

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,8 @@ const bDays = businessDays({
 });
 ```
 
+## Notes
+
 ### About holidays
 
 By default, when initialized without a state abbreviation, businessDays handles 10 U.S. public holidays as non-business days:
@@ -179,7 +181,7 @@ If those days fall on a weekend, substitution days are used based on rules defin
 
 For more information about holiday rules, consult the documentation for [date-holidays](https://www.npmjs.com/package/date-holidays).
 
-### Notes
+### Contributions
 If you find any bugs or have any suggestions for improvements, please feel free to open an issue or submit a pull request. Contributions are welcome!
 
 ### License

--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,7 @@ const bDays = businessDays({
 
 ## Notes
 
-### About holidays
+### Holidays and substitution days
 
 By default, when initialized without a state abbreviation, businessDays handles 10 U.S. public holidays as non-business days:
 

--- a/src/tests/fixtures.js
+++ b/src/tests/fixtures.js
@@ -16,7 +16,7 @@ export const CUSTOM_HOLIDAYS_2 = [
     name: "Groundhog Day",
   },
   {
-    rule: "06-19",
-    name: "Juneteenth",
+    rule: "07-15",
+    name: "Saint Swithin's Day",
   },
 ];

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -40,16 +40,28 @@ test("getHolidays returns an array", () => {
   expect(Array.isArray(holidayList)).toBe(true);
 });
 
-test("getHolidays returns 11 public holidays in 2020 when businessDays is initalized without state abbreviation", () => {
+test("getHolidays returns 10 public holidays in 2020 when businessDays is initalized without state abbreviation", () => {
   const bDaysObj = businessDays();
   const holidayList = bDaysObj.getHolidays(2020);
-  expect(holidayList.length).toBe(11);
+  expect(holidayList.length).toBe(11); // list includes substitution for Independence Day
+  const holsNoSubs = holidayList.filter((item) => !item.substitute);
+  expect(holsNoSubs.length).toBe(10);
 });
 
-test("getHolidays returns 12 public holidays in 2020 when businessDays is initalized with 'pa'", () => {
+test("getHolidays returns 11 public holidays in 2022 when businessDays is initalized without state abbreviation", () => {
+  // Juneteenth was added as a public holiday in 2021, bringing the number of federal holidays to 11
+  const bDaysObj = businessDays();
+  const holidayList = bDaysObj.getHolidays(2022);
+  const holsNoSubs = holidayList.filter((item) => !item.substitute);
+  expect(holsNoSubs.length).toBe(11);
+});
+
+test("getHolidays returns 12 public holidays in 2022 when businessDays is configured for Pennsylvania", () => {
+  // Pennsylvania considers Flag Day (06-14) a public holiday in addition to the 11 federal holidays
   const bDaysObj = businessDays({ state: "pa" });
-  const holidayList = bDaysObj.getHolidays(2020);
-  expect(holidayList.length).toBe(12);
+  const holidayList = bDaysObj.getHolidays(2022);
+  const holsNoSubs = holidayList.filter((item) => !item.substitute);
+  expect(holsNoSubs.length).toBe(12);
 });
 
 // CHECK DAYS
@@ -318,19 +330,20 @@ test("Add Groundhog Day to public holiday list", () => {
   expect(bDaysObj.check(groundhogDay2018)).toBe(false);
 });
 
-test("Add Groundhog Day and Juneteenth to public holiday list", () => {
+test("Add Groundhog Day and Saint Swithin's Day to public holiday list for Pa.", () => {
   const bDaysObj = businessDays({
     state: "pa",
     addHolidays: CUSTOM_HOLIDAYS_2,
   });
-  const holidayList = bDaysObj.getHolidays(2018);
-  const holidayListClean = holidayList.map((item) => item.name.toLowerCase());
+  const holidayList = bDaysObj.getHolidays(2023);
+  const holidayListClean = holidayList.filter(item => !item.substitute).map((item) => item.name.toLowerCase());
   expect(holidayListClean).toContain("groundhog day");
-  expect(holidayListClean.length).toBe(13);
-  const groundhogDay2018 = "2018-02-02"; // Friday, Feb 2, 2018
-  const juneteenth2018 = "2018-06-19"; // Tues, June 19, 2018
-  expect(bDaysObj.check(groundhogDay2018)).toBe(false);
-  expect(bDaysObj.check(juneteenth2018)).toBe(false);
+  expect(holidayListClean).toContain("saint swithin's day");
+  expect(holidayListClean.length).toBe(14);
+  const groundhogDay2023 = "2023-02-02"; // February 2, 2023
+  const juneteenth2023 = "2023-07-15"; // July 15, 2023
+  expect(bDaysObj.check(groundhogDay2023)).toBe(false);
+  expect(bDaysObj.check(juneteenth2023)).toBe(false);
 });
 
 test("Add Groundhog Day and exclude Christmas Day and Presidents' Day", () => {


### PR DESCRIPTION
## What's this PR do?
Updates the readme and tests to acknowledge Juneteenth was added as a federal holiday in 2021. Also makes a few small unrelated readme formatting tweaks.

## Why are we doing this? How does it help us?
#4 upgraded date-holidays to ensure this package considers Juneteenth a public holiday from 2021 onwards, however corresponding changes weren't made to the readme text or tests. This PR makes it clearer that Juneteenth is considered a public holiday.

## Are there any smells or added technical debt to note?

## TODOs / next steps:
<!-- Remove any checklist items that don't apply to your PR. -->
<!-- Examples:  "Run django migration," "Slack notify #all-general," etc. -->
* [ ] *your TODO here*
